### PR TITLE
foblo+reptile

### DIFF
--- a/configs/foblo_ssl+sl.toml
+++ b/configs/foblo_ssl+sl.toml
@@ -1,0 +1,45 @@
+[data]
+ssl.manifest = "/path/to/manifests/ssl/.csv"
+ssl.by_lang = true
+ssl.lang_task_chunk_duration = 36000
+supervised.manifest = "/path/to/manifests/sl/.csv"
+supervised.alignments_path = "/path/to/alignment/sl/.csv"
+supervised.by_lang = true
+supervised.random_seed = 100
+
+[run]
+model_type = "spidr_reset"
+compile = false
+save_interval = 10000
+keep_latest = 2
+workdir = "/path/to/workdir"
+wandb_mode = "offline"
+wandb_project = "spidr_adapt_test"
+wandb_name = "foblo_ssl+sl"
+init_ckpt = "/path/to/ssl+sl/initialization/checkpoint.pt"
+
+[model]
+encoder_layer_drop = 0.05
+ema_start_decay = 1.0
+ema_final_decay = 1.0
+supervised_layer = 8
+supervised_every_step = 10
+supervised_languages = ['sk', 'sl', 'nl', 'lt', 'sv', 'it', 'mt', 'pt', 'hu', 'et', 'hr', 'es', 'el', 'ro', 'bg', 'lv', 'fi', 'pl', 'cs']
+
+[optimizer]
+lr = 5e-5
+scheduler = "cyclic_dual_loss"
+max_steps = 200_000
+warmup_steps = 12_000
+hold_steps = 88_000
+decay_steps = 100_000
+
+[meta_update]
+num_workers = 8
+task_interval = 2000
+method = "foblo"
+beta = 0.01
+inner_step = 1800
+
+[validation]
+english.manifest = "/path/to/manifests/.csv"

--- a/configs/foblo_ssl.toml
+++ b/configs/foblo_ssl.toml
@@ -1,0 +1,45 @@
+[data]
+ssl.manifest = "/path/to/manifests/ssl/.csv"
+ssl.by_lang = true
+ssl.lang_task_chunk_duration = 36000
+supervised.manifest = "/path/to/manifests/sl/.csv"
+supervised.alignments_path = "/path/to/alignment/sl/.csv"
+supervised.by_lang = true
+supervised.random_seed = 100
+
+[run]
+model_type = "spidr_reset"
+compile = false
+save_interval = 10000
+keep_latest = 2
+workdir = "/path/to/workdir"
+wandb_mode = "offline"
+wandb_project = "spidr_adapt_test"
+wandb_name = "foblo_ssl"
+init_ckpt = "/path/to/ssl/initialization/checkpoint.pt"
+
+[model]
+encoder_layer_drop = 0.05
+ema_start_decay = 1.0
+ema_final_decay = 1.0
+supervised_layer = 8
+supervised_every_step = 10
+supervised_languages = ['sk', 'sl', 'nl', 'lt', 'sv', 'it', 'mt', 'pt', 'hu', 'et', 'hr', 'es', 'el', 'ro', 'bg', 'lv', 'fi', 'pl', 'cs']
+
+[optimizer]
+lr = 5e-5
+scheduler = "cyclic_dual_loss"
+max_steps = 200_000
+warmup_steps = 12_000
+hold_steps = 88_000
+decay_steps = 100_000
+
+[meta_update]
+num_workers = 8
+task_interval = 2000
+method = "foblo"
+beta = 0.1
+inner_step = 1800
+
+[validation]
+english.manifest = "/path/to/manifests/.csv"

--- a/configs/reptile_ssl+sl.toml
+++ b/configs/reptile_ssl+sl.toml
@@ -1,0 +1,38 @@
+[data]
+ssl.manifest = "/path/to/manifests/ssl/.csv"
+ssl.by_lang = true
+ssl.lang_task_chunk_duration = 36000
+
+[run]
+model_type = "spidr_reset"
+compile = false
+save_interval = 10000
+keep_latest = 2
+workdir = "/path/to/workdir"
+wandb_mode = "offline"
+wandb_project = "spidr_adapt_test"
+wandb_name = "reptile_ssl+sl"
+init_ckpt = "/path/to/ssl+sl/initialization/checkpoint.pt"
+
+[model]
+encoder_layer_drop = 0.05
+ema_start_decay = 1.0
+ema_final_decay = 1.0
+
+[optimizer]
+lr = 5e-5
+scheduler = "cyclic"
+max_steps = 200_000
+warmup_steps = 12_000
+hold_steps = 88_000
+decay_steps = 100_000
+
+[meta_update]
+num_workers = 8
+task_interval = 2000
+method = "reptile"
+beta = 0.1
+inner_step = 2000
+
+[validation]
+english.manifest = "/path/to/manifests/.csv"

--- a/configs/reptile_ssl.toml
+++ b/configs/reptile_ssl.toml
@@ -1,0 +1,38 @@
+[data]
+ssl.manifest = "/path/to/manifests/ssl/.csv"
+ssl.by_lang = true
+ssl.lang_task_chunk_duration = 36000
+
+[run]
+model_type = "spidr_reset"
+compile = false
+save_interval = 10000
+keep_latest = 2
+workdir = "/path/to/workdir"
+wandb_mode = "offline"
+wandb_project = "spidr_adapt_test"
+wandb_name = "reptile_ssl"
+init_ckpt = "/path/to/ssl/initialization/checkpoint.pt"
+
+[model]
+encoder_layer_drop = 0.05
+ema_start_decay = 1.0
+ema_final_decay = 1.0
+
+[optimizer]
+lr = 5e-5
+scheduler = "cyclic"
+max_steps = 200_000
+warmup_steps = 12_000
+hold_steps = 88_000
+decay_steps = 100_000
+
+[meta_update]
+num_workers = 8
+task_interval = 2000
+method = "reptile"
+beta = 0.1
+inner_step = 2000
+
+[validation]
+english.manifest = "/path/to/manifests/.csv"

--- a/src/spidr_adapt/checkpoint.py
+++ b/src/spidr_adapt/checkpoint.py
@@ -150,7 +150,7 @@ class Checkpointer:
             return False
         if path.name == "final.pt":
             logger.warning("Loading final checkpoint")
-        ckpt = torch.load(path, map_location=torch.device("cpu"), weights_only=True)
+        ckpt = torch.load(path, map_location=torch.device("cpu"), weights_only=False)
         self._state.step = ckpt["step"]
         self._state.epoch = ckpt["epoch"]
         self._state.supervised_epoch = ckpt["supervised_epoch"]
@@ -173,7 +173,7 @@ class Checkpointer:
         return True
 
     def load_existing_run(self) -> bool:
-        if (path := self.last) is None:
+        if (path := self.last) is None or self.last.stem == "step_0":
             return False
         return self._load_from_path(path)
 

--- a/src/spidr_adapt/config.py
+++ b/src/spidr_adapt/config.py
@@ -9,10 +9,10 @@ from typing import Literal, NotRequired, TypedDict
 
 ALIGNMENT_FREQ: int = 100
 SAMPLE_RATE: int = 16_000
-DEFAULT_CONV_LAYER_CONFIG: list[tuple[int, int, int]] = [(512, 10, 5)] + [(512, 3, 2)] * 4 + [(512, 2, 2)] * 2
+DEFAULT_CONV_LAYER_CONFIG: list[tuple[int, int, int]] = [[512, 10, 5]] + [[512, 3, 2]] * 4 + [[512, 2, 2]] * 2
 
 MaskingStrategy = Literal["static", "uniform", "normal", "poisson"]
-ModelType = Literal["dinosr", "spidr"]
+ModelType = Literal["dinosr", "spidr", "spidr_reset"]
 
 
 class SlurmConfig(TypedDict):
@@ -95,7 +95,7 @@ class OptimizerConfig:
     rsqrt_timescale: int = 10_000
     rsqrt_shift: int = 0
 
-    scheduler: Literal["tristage", "cosine", "rsqrt", "constant", "cyclic"] = "tristage"
+    scheduler: Literal["tristage", "cosine", "rsqrt", "constant", "cyclic", "cyclic_dual_loss"] = "tristage"
     upper_envelope_shape: Literal["tristage", "constant", "warmupconstant"] = "tristage"  # for use with CyclicLR
     within_cycle_warmup_steps: int = 600  # for use with CyclicLR
 
@@ -163,7 +163,8 @@ class MetaUpdateConfig:
     method: Literal["reptile", "foblo"] | None = None
     num_workers: int = 8
     beta: float = 0.1
-    inner_step: int = 2000
+    task_interval: int = 2000
+    inner_step: int = 1800
 
 
 @dataclass(frozen=True)

--- a/src/spidr_adapt/data/dataset.py
+++ b/src/spidr_adapt/data/dataset.py
@@ -530,12 +530,11 @@ class InterleaveSLDatasetLoader:
         self.epoch = epoch
         self.start_new_epoch(BatchType.SSL)
 
-        if cfg.model.supervised_every_step:
-            supervised_data_cfg = (
-                cfg.data.get(BatchType.SUPERVISED.name.lower(), None) if isinstance(cfg.data, dict) else None
-            )
-            assert supervised_data_cfg, "Supervised interleaved training requires supervised data in the config."
-            self.supervised_loader, self.supervised_loader_iter = self.initialize_loaders(supervised_data_cfg)
+        self.supervised_data_cfg = (
+            cfg.data.get(BatchType.SUPERVISED.name.lower(), None) if isinstance(cfg.data, dict) else None
+        )
+        if self.supervised_data_cfg:
+            self.supervised_loader, self.supervised_loader_iter = self.initialize_loaders(self.supervised_data_cfg)
             self.supervised_epoch = supervised_epoch
             self.start_new_epoch(BatchType.SUPERVISED)
 
@@ -577,7 +576,8 @@ class InterleaveSLDatasetLoader:
         self.ssl_loader.batch_sampler.set_batch_language_task(step, reset_interval)
         self.ssl_loader_iter = iter(self.ssl_loader)
         batch_language = self.ssl_loader.batch_sampler.batch_language.split("_chunk")[0]
-        if self.cfg.model.supervised_every_step:
+
+        if self.supervised_data_cfg:
             self.supervised_loader.batch_sampler.set_batch_language_task(
                 step, reset_interval, fixed_language=batch_language
             )

--- a/src/spidr_adapt/meta_train.py
+++ b/src/spidr_adapt/meta_train.py
@@ -17,8 +17,8 @@ from spidr_adapt.checkpoint import Checkpointer, remove_param_group
 from spidr_adapt.config import SAMPLE_RATE, Config, DataConfig, MetaUpdateConfig, ResumeConfig, read_config
 from spidr_adapt.data import BatchType, InterleaveSLDatasetLoader, get_number_of_data_chunks
 from spidr_adapt.environment import pg_ddp, pg_metalearning, setup_training
-from spidr_adapt.metalearning import MetaUpdater, Reptile
-from spidr_adapt.models import LossWeightDefinition, SpidRWithReset, build_model
+from spidr_adapt.metalearning import META_UPDATER_CLASSES
+from spidr_adapt.models import LossWeightDefinition, build_model
 from spidr_adapt.optimizer import build_optimizer
 from spidr_adapt.tools import AverageMeters, profiler_context
 from spidr_adapt.train import init_wandb, launch_validation
@@ -50,7 +50,7 @@ def get_meta_train_dataloader(
     """
     ssl_data_cfg = cfg.data if isinstance(cfg.data, DataConfig) else cfg.data[BatchType.SSL.name.lower()]
     supervised_data_cfg = None if isinstance(cfg.data, DataConfig) else cfg.data.get(BatchType.SUPERVISED.name.lower())
-    num_reset = step // cfg.meta_update.inner_step
+    num_reset = step // cfg.meta_update.task_interval
     if num_reset == 0:
         return InterleaveSLDatasetLoader(cfg, epoch, supervised_epoch=supervised_epoch)
     # create new ssl data config to change seed
@@ -83,18 +83,26 @@ def should_reset_data_loader(
     return 0 <= batch_language_index < metalearning_size
 
 
-def get_meta_updater(meta_update_cfg: MetaUpdateConfig, model: SpidRWithReset) -> MetaUpdater:
+def get_meta_loss_weights_and_batch_type(
+    step: int, meta_update_cfg: MetaUpdateConfig
+) -> tuple[LossWeightDefinition, BatchType]:
+    """Determine the loss weights and data type based on the current step."""
     if meta_update_cfg.method == "reptile":
-        meta_updater = Reptile(model=model, beta=meta_update_cfg.beta)
+        loss_weights = LossWeightDefinition(ssl=1.0, supervised=0.0)
+        batch_type = BatchType.SSL
     elif meta_update_cfg.method == "foblo":
-        # TODO: Jiayi to implement FOBLO
-        raise ValueError("FOBLO not implemented yet")
+        if (step % meta_update_cfg.task_interval) < meta_update_cfg.inner_step:
+            loss_weights = LossWeightDefinition(ssl=1.0, supervised=0.0)
+            batch_type = BatchType.SSL
+        else:
+            loss_weights = LossWeightDefinition(ssl=0.0, supervised=1.0)
+            batch_type = BatchType.SUPERVISED
     else:
         raise ValueError(f"Unknown meta_update method: {meta_update_cfg.method}")
-    return meta_updater
+    return loss_weights, batch_type
 
 
-def meta_train(cfg: Config) -> None:  # noqa: PLR0914, PLR0915, C901
+def meta_train(cfg: Config) -> None:  # noqa: C901, PLR0912, PLR0914, PLR0915
     with ExitStack() as stack:
         logger.info("Starting job")
         setup_training(
@@ -118,8 +126,12 @@ def meta_train(cfg: Config) -> None:  # noqa: PLR0914, PLR0915, C901
         dtype = {"float32": torch.float32, "float16": torch.float16, "bfloat16": torch.bfloat16}[cfg.optimizer.dtype]
         model = build_model(cfg=cfg.model, model_type=cfg.run.model_type, checkpoint=cfg.run.init_ckpt)
         model = model.to(device).train()
+        model.set_task_internal(getattr(cfg.meta_update, "task_interval", None))
         optimizer, scaler, scheduler = build_optimizer(
-            model, cfg.optimizer, getattr(cfg.meta_update, "inner_step", None)
+            model,
+            cfg.optimizer,
+            getattr(cfg.meta_update, "task_interval", None),
+            getattr(cfg.meta_update, "inner_step", None),
         )
         dist.barrier(device_ids=[device.index])
         ckpt = Checkpointer(cfg.run.dir, cfg.run.save_interval, cfg.run.keep_latest)
@@ -131,7 +143,8 @@ def meta_train(cfg: Config) -> None:  # noqa: PLR0914, PLR0915, C901
         loader = get_meta_train_dataloader(
             cfg, step, epoch, supervised_epoch, metalearning_size, metalearning_rank, num_tasks
         )
-        loader.set_task(step, cfg.meta_update.inner_step)
+        loader.set_task(step, cfg.meta_update.task_interval)
+
         if not resuming and is_main and ckpt.save(step, epoch, supervised_epoch=supervised_epoch):
             launch_validation(cfg, ResumeConfig(step=step, checkpoint=ckpt.last, results=ckpt.metrics))
         if cfg.run.compile:
@@ -140,7 +153,10 @@ def meta_train(cfg: Config) -> None:  # noqa: PLR0914, PLR0915, C901
         ddp_model = DistributedDataParallel(
             model, device_ids=[device.index], find_unused_parameters=True, process_group=pg_ddp()
         )
-        meta_updater = get_meta_updater(cfg.meta_update, model)
+
+        meta_updater = META_UPDATER_CLASSES[cfg.meta_update.method](
+            model=model, beta=cfg.meta_update.beta, task_interval=cfg.meta_update.task_interval
+        )
 
         logger.info("Starting training loop")
         meters = AverageMeters(
@@ -149,13 +165,14 @@ def meta_train(cfg: Config) -> None:  # noqa: PLR0914, PLR0915, C901
         profiler = stack.enter_context(profiler_context(cfg.run.dir / "trace.html" if is_main else None))
         pbar = stack.enter_context(tqdm(total=cfg.optimizer.max_steps, initial=step, disable=not is_main))
         while step < cfg.optimizer.max_steps:
-            batch = loader.load_batch_data(BatchType.SSL)
+            loss_weights, batch_type = get_meta_loss_weights_and_batch_type(step, cfg.meta_update)
+            batch = loader.load_batch_data(batch_type)
+
             if step >= cfg.optimizer.max_steps:
                 break
             if step == cfg.model.freeze_step and len(optimizer.param_groups) > 1:
                 remove_param_group(optimizer, 1)
 
-            loss_weights = LossWeightDefinition(ssl=1.0, supervised=0.0)
             with torch.autocast("cuda", dtype, cfg.optimizer.mixed_precision):
                 ssl_loss, supervised_loss, outputs = ddp_model(batch.to(device), loss_weights=loss_weights)
             num_frames = torch.tensor(ssl_loss.size(0), dtype=torch.long, device=device)
@@ -172,18 +189,18 @@ def meta_train(cfg: Config) -> None:  # noqa: PLR0914, PLR0915, C901
             scheduler.step()
             step += 1
             ema_decay = model.update_ema(step)
-            if step % cfg.meta_update.inner_step == 0:
-                # TODO: Jiayi to implement forward of FOBLO
-                meta_updater(model)  # meta_train update after inner loop
 
-                # reset task after inner loop
+            if step % cfg.meta_update.task_interval == 0:
+                meta_updater(model)
                 if should_reset_data_loader(
-                    step, cfg.meta_update.inner_step, metalearning_size, metalearning_rank, num_tasks
+                    step, cfg.meta_update.task_interval, metalearning_size, metalearning_rank, num_tasks
                 ):
                     loader = get_meta_train_dataloader(
                         cfg, step, epoch, supervised_epoch, metalearning_size, metalearning_rank, num_tasks
                     )
-                loader.set_task(step, cfg.meta_update.inner_step)
+                loader.set_task(step, cfg.meta_update.task_interval)
+            if step % cfg.meta_update.task_interval == cfg.meta_update.inner_step:
+                meta_updater.perform_inner_update(model)
 
             meters.update(loss=loss.detach(), supervised_loss=supervised_loss.detach(), ssl_loss=ssl_loss.detach())
             meters.update(batch_size=batch.waveforms.size(0), grad_norm=grad_norm)

--- a/src/spidr_adapt/metalearning/__init__.py
+++ b/src/spidr_adapt/metalearning/__init__.py
@@ -1,7 +1,13 @@
 # Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
 """Reptile wrapper."""
 
+from spidr_adapt.metalearning.foblo import FOBLO
 from spidr_adapt.metalearning.meta_updater import MetaUpdater
 from spidr_adapt.metalearning.reptile import Reptile
 
-__all__ = ["MetaUpdater", "Reptile"]
+__all__ = ["FOBLO", "MetaUpdater", "Reptile"]
+
+META_UPDATER_CLASSES = {
+    "reptile": Reptile,
+    "foblo": FOBLO,
+}

--- a/src/spidr_adapt/metalearning/foblo.py
+++ b/src/spidr_adapt/metalearning/foblo.py
@@ -1,26 +1,60 @@
 # Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
 """FOBLO wrapper implementation."""
 
+import copy
 import logging
 
 import torch
+import torch.distributed as dist
 from torch import nn
 
-from spidr_adapt.metalearning.meta_updater import MetaUpdater
+from spidr_adapt.environment import pg_metalearning
+from spidr_adapt.metalearning.meta_updater import MetaUpdater, parameters_to_sync
+from spidr_adapt.metalearning.utils import all_reduce_coalesced
 
 logger = logging.getLogger()
 
 
 class FOBLO(MetaUpdater):
-    def __init__(self, *, model: nn.Module, beta: float) -> None:
+    def __init__(self, *, model: nn.Module, beta: float, task_interval: int) -> None:
         """Distributed FOBLO.
 
         This class is generic and works with any PyTorch Module.
         """
-        # TODO: Jiayi to add FOBLO init
-        super().__init__(model=model, beta=beta)
+        super().__init__(model=model, beta=beta, task_interval=task_interval)
+        self.theta_inner = copy.deepcopy(model).eval()
+
+    @torch.no_grad()
+    def perform_inner_update(self, model: nn.Module) -> None:
+        step = model.current_step.item() - 1
+        logger.debug(
+            "FOBLO updates theta_ssl at episode %s at local step %s, at the global step %s.",
+            step // self.task_interval,
+            step % self.task_interval,
+            step,
+        )
+        theta_inner_lerp, theta_inner_copy = parameters_to_sync(self.theta_inner)
+        worker_lerp, worker_copy = parameters_to_sync(model)
+        torch._foreach_copy_(theta_inner_copy, worker_copy)
+        torch._foreach_copy_(theta_inner_lerp, worker_lerp)
 
     @torch.no_grad()
     def forward(self, model: nn.Module) -> None:
-        # TODO: Jiayi to add FOBLO forward
-        pass
+        step = model.current_step.item() - 1
+        logger.debug(
+            "FOBLO meta-update at episode %s at local step %s, at the global step %s.",
+            step // self.task_interval,
+            step % self.task_interval,
+            step,
+        )
+        central_lerp, central_copy = parameters_to_sync(self.central)
+        worker_lerp, worker_copy = parameters_to_sync(model)
+        theta_inner_lerp, _ = parameters_to_sync(self.theta_inner)
+        if central_copy:
+            torch._foreach_copy_(central_copy, worker_copy)
+        if central_lerp:
+            torch._foreach_add_(central_lerp, worker_lerp, alpha=self.beta)
+            torch._foreach_add_(central_lerp, theta_inner_lerp, alpha=-self.beta)
+            if self.num_workers > 1:
+                all_reduce_coalesced(central_lerp, pg_metalearning(), op=dist.ReduceOp.AVG)
+        model.load_state_dict(self.central.state_dict())

--- a/src/spidr_adapt/metalearning/meta_updater.py
+++ b/src/spidr_adapt/metalearning/meta_updater.py
@@ -30,7 +30,7 @@ def parameters_to_sync(model: nn.Module) -> tuple[tuple[nn.Parameter, ...], tupl
 
 
 class MetaUpdater(nn.Module):
-    def __init__(self, *, model: nn.Module, beta: float) -> None:
+    def __init__(self, *, model: nn.Module, beta: float, task_interval: int) -> None:
         """Distributed MetaUpdater.
 
         This class is generic and works with any PyTorch Module.
@@ -38,10 +38,15 @@ class MetaUpdater(nn.Module):
         """
         super().__init__()
         self.beta = beta
+        self.task_interval = task_interval
         self.num_workers = dist.get_world_size(pg_metalearning()) if dist.is_initialized() else 1
         if self.num_workers > 1:
             sync_module_states(model, pg_metalearning(), src=0)
         self.central = copy.deepcopy(model).eval()
+
+    @torch.no_grad()
+    def perform_inner_update(self, model: nn.Module) -> None:
+        pass
 
     @torch.no_grad()
     def forward(self, model: nn.Module) -> None:

--- a/src/spidr_adapt/metalearning/reptile.py
+++ b/src/spidr_adapt/metalearning/reptile.py
@@ -15,15 +15,22 @@ logger = logging.getLogger()
 
 
 class Reptile(MetaUpdater):
-    def __init__(self, *, model: nn.Module, beta: float) -> None:
+    def __init__(self, *, model: nn.Module, beta: float, task_interval: int) -> None:
         """Distributed Reptile.
 
         This class is generic and works with any PyTorch Module.
         """
-        super().__init__(model=model, beta=beta)
+        super().__init__(model=model, beta=beta, task_interval=task_interval)
 
     @torch.no_grad()
     def forward(self, model: nn.Module) -> None:
+        step = model.current_step.item() - 1
+        logger.debug(
+            "Reptile meta-update at episode %s at local step %s, at the global step %s.",
+            step // self.task_interval,
+            step % self.task_interval,
+            step,
+        )
         logger.debug("Reptile updates performed at step %s", model.current_step.item())
         central_lerp, central_copy = parameters_to_sync(self.central)
         worker_lerp, worker_copy = parameters_to_sync(model)

--- a/src/spidr_adapt/models/spidr_reset.py
+++ b/src/spidr_adapt/models/spidr_reset.py
@@ -55,13 +55,15 @@ class SpidRWithReset(SpidR):
 
     def __init__(self, cfg: SpidRWithResetConfig) -> None:
         super().__init__(cfg)
-        self.reset_interval = cfg.reset_interval
         self.adapt_heads = cfg.adapt_heads
 
+    def set_task_internal(self, task_interval: int) -> None:
+        self.task_interval = task_interval
+
     def should_reset(self, step: int) -> bool:
-        if self.reset_interval is None or not self.training:
+        if self.task_interval is None or not self.training:
             return False
-        return step % self.reset_interval == 0
+        return step % self.task_interval == 0
 
     def get_ssl_loss(
         self,
@@ -76,7 +78,7 @@ class SpidRWithReset(SpidR):
         losses = torch.zeros(interm[0].shape[0], device=device)
         target_ppl, pred_ppl = torch.zeros((), device=device), torch.zeros((), device=device)
         if should_reset:
-            logger.info("Reset codebook and heads at step %s", self.current_step.item())
+            logger.info("Active Forgetting on codebook and heads at step %s", self.current_step.item())
             reset_codebooks_and_heads(self)
         for i, (y, target) in enumerate(zip(interm, targets, strict=True)):
             onehot_target = self.codebooks[i](target)

--- a/src/spidr_adapt/models/utils.py
+++ b/src/spidr_adapt/models/utils.py
@@ -2,6 +2,7 @@
 """Model loading utilities."""
 
 import json
+import logging
 import typing as tp
 import warnings
 from collections import OrderedDict
@@ -13,34 +14,44 @@ import torch
 from torch.hub import load_state_dict_from_url
 from torch.nn.modules.utils import consume_prefix_in_state_dict_if_present
 
-from spidr_adapt.config import DinoSRConfig, ModelType, SpidRConfig
+from spidr_adapt.config import DinoSRConfig, ModelType, SpidRConfig, SpidRWithResetConfig
 from spidr_adapt.models.dinosr import DinoSR
 from spidr_adapt.models.spidr import SpidR
+from spidr_adapt.models.spidr_reset import SpidRWithReset
+
+logger = logging.getLogger()
 
 
 def model_from_raw_checkpoint(
     model_class: type[SpidR] | type[DinoSR],
     config_class: type[DinoSRConfig] | type[SpidRConfig],
     ckpt: str | Path,
+    cfg: SpidRWithResetConfig | None = None,
 ) -> DinoSR | SpidR:
     path = Path(ckpt)
     if path.suffix != ".pt":
         raise ValueError("Only .pt files are supported.")
-    if (path.parent / "config.json").is_file():
-        with (path.parent / "config.json").open() as f:
-            json_cfg = json.load(f)
-            if "model" in json_cfg:
-                json_cfg = json_cfg["model"]
-            cfg = config_class(**json_cfg)
-    else:
-        warnings.warn("Config file not found when loading checkpoint. Using default config.", stacklevel=2)
-        cfg = config_class()
+    if cfg is None:
+        if (path.parent / "config.json").is_file():
+            with (path.parent / "config.json").open() as f:
+                json_cfg = json.load(f)
+                if "model" in json_cfg:
+                    json_cfg = json_cfg["model"]
+                cfg = config_class(**json_cfg)
+        else:
+            warnings.warn("Config file not found when loading checkpoint. Using default config.", stacklevel=2)
+            cfg = config_class()
+
     instance = model_class(cfg)
     state_dict = torch.load(path, map_location="cpu", weights_only=True)
     if "model" in state_dict:
         state_dict = state_dict["model"]
     consume_prefix_in_state_dict_if_present(state_dict, "module.")
-    instance.load_state_dict(state_dict)
+    missing_keys, unexpected_keys = instance.load_state_dict(state_dict, strict=False)
+    if len(missing_keys) > 0:
+        logger.warning("Missing keys when loading state_dict %s", missing_keys)
+    if len(unexpected_keys) > 0:
+        logger.warning("Unexpected keys when loading state_dict %s", unexpected_keys)
     return instance
 
 
@@ -56,8 +67,12 @@ def build_model(
                 return model_from_raw_checkpoint(DinoSR, DinoSRConfig, checkpoint)
             case "spidr":
                 return model_from_raw_checkpoint(SpidR, SpidRConfig, checkpoint)
+            case "spidr_reset":
+                return model_from_raw_checkpoint(SpidRWithReset, SpidRWithResetConfig, checkpoint, cfg)
             case _:
                 raise ValueError(f"Model type not recognized, acceptable models are {tp.get_args(ModelType)}.")
+    if isinstance(cfg, SpidRWithResetConfig):
+        return SpidRWithReset(cfg)
     if isinstance(cfg, SpidRConfig):
         return SpidR(cfg)
     if isinstance(cfg, DinoSRConfig):  # Must be last condition because SpidRConfig is subclass of DinoSRConfig

--- a/src/spidr_adapt/optimizer.py
+++ b/src/spidr_adapt/optimizer.py
@@ -12,17 +12,15 @@ from spidr_adapt.config import OptimizerConfig
 
 
 class CyclicLR(LRScheduler):
-    def __init__(self, opt: Optimizer, cfg: OptimizerConfig, reset_interval: int, last_epoch: int = -1) -> None:
+    def __init__(self, opt: Optimizer, cfg: OptimizerConfig, task_interval: int, last_epoch: int = -1) -> None:
         self.opt = opt
         self.cfg = cfg
         assert self.cfg.within_cycle_warmup_steps, "within_cycle_warmup_steps is required for CyclicLR"
-        self.reset_interval = reset_interval
+        self.task_interval = task_interval
         self.init_lr_scale = cfg.init_lr_scale if cfg.warmup_steps > 0 else 1
         super().__init__(opt, last_epoch)
 
-    def upper_envelope(self, cycle_index: int) -> list[float]:
-        envelope_index = cycle_index * self.reset_interval
-        upper_envelope_shape = self.cfg.upper_envelope_shape
+    def upper_envelope(self, envelope_index: int, upper_envelope_shape: str) -> list[float]:
         if upper_envelope_shape == "tristage":
             end_of_hold_steps = self.cfg.hold_steps + self.cfg.warmup_steps
             if self.last_epoch <= self.cfg.warmup_steps:
@@ -53,19 +51,54 @@ class CyclicLR(LRScheduler):
         return envelope_value
 
     def get_lr(self) -> list[float]:
-        cycle_index = self.last_epoch // self.reset_interval + 1  # lr value of the end of each reset envelope
-        max_lr = self.upper_envelope(cycle_index)  # Get the max lr for the current cycle
+        envelope_index = (self.last_epoch // self.task_interval + 1) * self.task_interval
+        max_lr = self.upper_envelope(envelope_index, self.cfg.upper_envelope_shape)
         min_lr = max_lr * self.init_lr_scale
-        if self.last_epoch % self.reset_interval < self.cfg.within_cycle_warmup_steps:  # Warmup phase
+        if self.last_epoch % self.task_interval < self.cfg.within_cycle_warmup_steps:  # Warmup phase
             return [
                 min_lr
-                + (max_lr - min_lr) * (self.last_epoch % self.reset_interval) / self.cfg.within_cycle_warmup_steps
+                + (max_lr - min_lr) * (self.last_epoch % self.task_interval) / self.cfg.within_cycle_warmup_steps
                 for _ in self.opt.param_groups
             ]
-        return [max_lr for _ in self.opt.param_groups]  # hold phase
+        return [max_lr for _ in self.opt.param_groups]
 
 
-def build_scheduler(opt: Optimizer, cfg: OptimizerConfig, reset_interval: int | None) -> LRScheduler:
+class CyclicDualLR(CyclicLR):
+    def __init__(
+        self,
+        opt: Optimizer,
+        cfg: OptimizerConfig,
+        task_interval: int,
+        inner_step: int,
+        last_epoch: int = -1,
+    ) -> None:
+        self.inner_step = inner_step
+        super().__init__(opt, cfg, task_interval, last_epoch)
+
+    def get_lr(self) -> list[float]:
+        if self.last_epoch % self.task_interval < self.inner_step:
+            envelope_index = (self.last_epoch // self.task_interval + 1) * self.task_interval
+            max_lr_ssl = self.upper_envelope(envelope_index, self.cfg.upper_envelope_shape)
+            min_lr_ssl = max_lr_ssl * self.init_lr_scale
+            if self.last_epoch % self.task_interval < self.cfg.within_cycle_warmup_steps:  # Warmup phase
+                return [
+                    min_lr_ssl
+                    + (max_lr_ssl - min_lr_ssl)
+                    * (self.last_epoch % self.task_interval)
+                    / self.cfg.within_cycle_warmup_steps
+                    for _ in self.opt.param_groups
+                ]
+            return [max_lr_ssl for _ in self.opt.param_groups]
+        lr_sl = self.upper_envelope(self.last_epoch, "tristage")
+        return [lr_sl for _ in self.opt.param_groups]
+
+
+def build_scheduler(
+    opt: Optimizer,
+    cfg: OptimizerConfig,
+    task_interval: int | None,
+    inner_step: int | None,
+) -> LRScheduler:
     init_lr_scale = cfg.init_lr_scale if cfg.warmup_steps > 0 else 1
     decay: LRScheduler
     if cfg.scheduler == "tristage":
@@ -92,13 +125,20 @@ def build_scheduler(opt: Optimizer, cfg: OptimizerConfig, reset_interval: int | 
         hold = LinearLR(opt, start_factor=1.0, total_iters=cfg.max_steps)
         return SequentialLR(opt, [warmup, hold], [cfg.warmup_steps])
     if cfg.scheduler == "cyclic":
-        assert reset_interval, "Reset interval is required for CyclicLR scheduler"
-        return CyclicLR(opt, cfg, reset_interval)
+        assert task_interval, "Reset interval is required for CyclicLR scheduler"
+        return CyclicLR(opt, cfg, task_interval)
+    if cfg.scheduler == "cyclic_dual_loss":
+        assert task_interval, "Reset interval is required for CyclicLR scheduler"
+        assert inner_step, "FOBLO wth inner_step is required for CyclicLR_firstorder scheduler"
+        return CyclicDualLR(opt, cfg, task_interval, inner_step)
     raise ValueError(f"Unknown scheduler: {cfg.scheduler}")
 
 
 def build_optimizer(
-    model: torch.nn.Module, cfg: OptimizerConfig, reset_interval: int | None = None
+    model: torch.nn.Module,
+    cfg: OptimizerConfig,
+    task_interval: int | None = None,
+    inner_step: int | None = None,
 ) -> tuple[AdamW, GradScaler, LRScheduler]:
     if cfg.dtype not in {"float32", "float16", "bfloat16"}:
         raise ValueError(cfg.dtype)
@@ -114,5 +154,5 @@ def build_optimizer(
 
     optimizer = AdamW(param_groups, lr=cfg.lr, weight_decay=cfg.weight_decay, betas=cfg.betas, eps=cfg.eps, fused=True)
     scaler = GradScaler("cuda", enabled=cfg.mixed_precision)
-    scheduler = build_scheduler(optimizer, cfg, reset_interval)
+    scheduler = build_scheduler(optimizer, cfg, task_interval, inner_step)
     return optimizer, scaler, scheduler

--- a/src/spidr_adapt/slurm.py
+++ b/src/spidr_adapt/slurm.py
@@ -45,6 +45,8 @@ def copy_code_to_submitit_folder(output_dir: Path) -> None:
         f"--exclude '*.pt' "
         f"--exclude '.ruff_cache/' "
         f"--exclude '.mypy_cache/' "
+        f"--exclude='.github/' "
+        f"--exclude='.venv/' "
         f"{root}/ {output_dir}"
     )
     subprocess.call([rsync_cmd], shell=True)


### PR DESCRIPTION
Merge FOBLO (clean) for spidr-adapt
- Logics update of MetaUpdater Class: 
   - FOBLO and Reptile are children classes of `MetaUpdater`.
   - FOBLO and Reptile share the same `meta_train.py`. 
     - dataloader:  switching from SSL to SL after all inner steps
     - loss weight: switching from SSL to SL after all inner steps
     - learning_rate scheduler:  cyclic (reptile) and cyclic_dual_loss(foblo)

   
- Updated configs files (consistent with our best model). 
   -  added `foblo_ssl.toml`, `foblo_ssl+sl.toml`, `reptile_ssl.toml` and `reptile_ssl+sl.toml`. The main difference is:
      - FOBLO: `inner_step = 1800`, `scheduler = "cyclic_dual_loss"`, `beta = 0.01 / 0.1`
      - Reptile:  `inner_step = 2000`, `scheduler = "cyclic"`, `beta = 0.1`
   - added `meta_update.task_interval` as a config to set up the training steps for each task.
- Important updates of loading init_ckpt in `models/utils.py`
   -   when init the model from init_ckpt, we should use the current `cfg` rather than the init_ckpt's config `json_cfg["model"]`or the default config `config_class()`. Otherwirse, the model hyperparameters in the `.toml` won't work! Especially for `supervised_layer=6/8`, `ema_start_decay=0.999/1.0`,  `ema_end_decay=0.9999/1.0`
   -  when load model parameters, `strict=False` avoids the mismatch of init_ckpt[SSL/SL] and Reptile, in terms of SL layers.

Test Plan: 

> python -m spidr_adapt ~/spidr-adapt/configs/foblo_ssl+sl.toml -A devai -N 2 -G 8 -c 8 -q h200_devai_high -t 4320 --dump ~/submitit

> python -m spidr_adapt ~/project/spidr-adapt/configs/reptile_ssl+sl.toml -A devai -N 2 -G 8 -c 8 -q h200_devai_high -t 4320 --dump ~/submitit