### PR TITLE
Fix git info writing

### DIFF
--- a/src/spidr_adapt/tools/git.py
+++ b/src/spidr_adapt/tools/git.py
@@ -32,7 +32,6 @@ def git_info() -> GitInfo:
 
 
 def write_git_info_if_available(path: str | Path) -> None:
-    return  # fix after first commit
     if not git_available():
         return
     info = git_info()


### PR DESCRIPTION
Adds back capability for git info writing (was disabled for initial commit)

Test
```
python -m spidr_adapt ~/spidr-adapt/configs/spidr_reptile_test.toml -A devai -N 2 -G 8 -c 8 -q h200_devai_high -t 4320 --dump ~/submitit
```